### PR TITLE
#25 - 예외처리 및 입력값 검증

### DIFF
--- a/address/build.gradle
+++ b/address/build.gradle
@@ -21,6 +21,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/address/src/main/java/assignment/address/controller/AddressController.java
+++ b/address/src/main/java/assignment/address/controller/AddressController.java
@@ -3,17 +3,16 @@ package assignment.address.controller;
 import assignment.address.dto.RequestAddressDto;
 import assignment.address.dto.ResponseAddressDto;
 import assignment.address.service.AddressService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.net.URL;
 
 @RequiredArgsConstructor
 @RequestMapping("/addresses")
@@ -34,14 +33,14 @@ public class AddressController {
     }
 
     @PostMapping
-    public ResponseEntity<ResponseAddressDto> create(@RequestBody RequestAddressDto addressDto) {
+    public ResponseEntity<ResponseAddressDto> create(@RequestBody @Valid RequestAddressDto addressDto) {
         ResponseAddressDto responseAddressDto = addressService.saveAddress(addressDto);
         return ResponseEntity.created(URI.create("/addresses/" + responseAddressDto.getId())).
                 body(responseAddressDto);
     }
 
     @PutMapping("/{addressId}")
-    public ResponseEntity<ResponseAddressDto> edit(@PathVariable Long addressId, RequestAddressDto addressDto) {
+    public ResponseEntity<ResponseAddressDto> edit(@PathVariable Long addressId, @RequestBody RequestAddressDto addressDto) {
         return ResponseEntity.ok(addressService.updateAddress(addressId, addressDto));
     }
 

--- a/address/src/main/java/assignment/address/domain/Address.java
+++ b/address/src/main/java/assignment/address/domain/Address.java
@@ -3,25 +3,23 @@ package assignment.address.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+@Builder
 @Getter
-@ToString(callSuper = true)
-@Entity
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 public class Address extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter
     @Column(nullable = false, unique = true, length = 100)
     private String name;
 
-    @Setter
     @Column(length = 100)
     private String phoneNumber;
 
-    @Setter
     private String residence;
 
     private Address(String name, String phoneNumber, String residence) {

--- a/address/src/main/java/assignment/address/dto/RequestAddressDto.java
+++ b/address/src/main/java/assignment/address/dto/RequestAddressDto.java
@@ -1,12 +1,18 @@
 package assignment.address.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class RequestAddressDto {
 
+    @NotBlank
     private String name;
+
+    @NotBlank
     private String phoneNumber;
+
+    @NotBlank
     private String residence;
 
     private RequestAddressDto(String name, String phoneNumber, String residence) {

--- a/address/src/main/java/assignment/address/global/GlobalExceptionHandler.java
+++ b/address/src/main/java/assignment/address/global/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package assignment.address.global;
+
+import assignment.address.global.code.CommonErrorCode;
+import assignment.address.global.code.ErrorCode;
+import assignment.address.global.exception.RestApiException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(RestApiException.class)
+    public ResponseEntity<Object> handlerCustomException(RestApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus()).body(errorCode.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException e) {
+        ErrorCode errorCode = CommonErrorCode.WRONG_PARAMETER;
+        return ResponseEntity.status(errorCode.getStatus()).body(errorCode.getMessage());
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        BindingResult bindingResult = e.getBindingResult();
+
+        StringBuilder builder = new StringBuilder();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            builder.append("[");
+            builder.append(fieldError.getField());
+            builder.append("](은)는 ");
+            builder.append(fieldError.getDefaultMessage());
+            builder.append(" 입력된 값: [");
+            builder.append(fieldError.getRejectedValue());
+            builder.append("]\n");
+        }
+        return ResponseEntity.status(status).body(builder.toString());
+    }
+}

--- a/address/src/main/java/assignment/address/global/code/CommonErrorCode.java
+++ b/address/src/main/java/assignment/address/global/code/CommonErrorCode.java
@@ -1,0 +1,16 @@
+package assignment.address.global.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    WRONG_PARAMETER(HttpStatus.BAD_REQUEST, "Wrong Parameter For Address")
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/address/src/main/java/assignment/address/global/code/ErrorCode.java
+++ b/address/src/main/java/assignment/address/global/code/ErrorCode.java
@@ -1,0 +1,10 @@
+package assignment.address.global.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    HttpStatus getStatus();
+
+    String getMessage();
+}

--- a/address/src/main/java/assignment/address/global/code/UserErrorCode.java
+++ b/address/src/main/java/assignment/address/global/code/UserErrorCode.java
@@ -1,0 +1,16 @@
+package assignment.address.global.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    NO_SUCH_ADDRESS(HttpStatus.NOT_FOUND, "No Such Address For That AddressID")
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/address/src/main/java/assignment/address/global/exception/NoSuchAddressException.java
+++ b/address/src/main/java/assignment/address/global/exception/NoSuchAddressException.java
@@ -1,0 +1,10 @@
+package assignment.address.global.exception;
+
+import assignment.address.global.code.ErrorCode;
+
+public class NoSuchAddressException extends RestApiException {
+
+    public NoSuchAddressException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/address/src/main/java/assignment/address/global/exception/RestApiException.java
+++ b/address/src/main/java/assignment/address/global/exception/RestApiException.java
@@ -1,0 +1,12 @@
+package assignment.address.global.exception;
+
+import assignment.address.global.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RestApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}


### PR DESCRIPTION
글로벌 예외 핸들러를 통해 예외에 따른 클라이언트의 응답을 정의하고,
주소록 생성에 필요한 입력값들을 검증하도록 하였음.

This Closes #25 